### PR TITLE
Add Support to .NET 6

### DIFF
--- a/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
+++ b/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/DataAnnotatedModelValidations/ValidatorMiddleware.cs
+++ b/DataAnnotatedModelValidations/ValidatorMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using HotChocolate;
 using HotChocolate.Resolvers;
 using Humanizer;
@@ -17,7 +19,11 @@ public partial class ValidatorMiddleware
 {
     private readonly FieldDelegate _next;
 
+#if NET7_0_OR_GREATER
     private static readonly Regex _bracketsRegex = BracketsRegex();
+#else
+    private static readonly Regex _bracketsRegex = new Regex("[\\[\\]]+", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
+#endif
 
     public ValidatorMiddleware(FieldDelegate next) => _next = next;
 
@@ -196,7 +202,9 @@ public partial class ValidatorMiddleware
             await _next(context).ConfigureAwait(false);
     }
 
+#if NET7_0_OR_GREATER
     [ExcludeFromCodeCoverage]
     [GeneratedRegex("[\\[\\]]+", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
     private static partial Regex BracketsRegex();
+#endif
 }


### PR DESCRIPTION
.NET 6 is the LTS so it seems to make sense to continue supporting it until EOL.
This allow to upgrade to HotChocolate while still being on .NET 6 