### PR TITLE
Fix validation on extended types

### DIFF
--- a/DataAnnotatedModelValidations.Tests/Pipeline/PipelineExecutionTests.GraphQL.cs
+++ b/DataAnnotatedModelValidations.Tests/Pipeline/PipelineExecutionTests.GraphQL.cs
@@ -1,4 +1,5 @@
 using DataAnnotatedModelValidations.Attributes;
+using HotChocolate.Language;
 
 namespace DataAnnotatedModelValidations.Tests.Pipeline;
 
@@ -69,7 +70,7 @@ public partial class PipelineExecutionTests
 
         public string? GetText([StringLength(100, MinimumLength = 5)] string? txt) => txt;
 
-        public string? GetTextIgnoreValidation([IgnoreModelValidation] [StringLength(100, MinimumLength = 5)] string? txt) => txt;
+        public string? GetTextIgnoreValidation([IgnoreModelValidation][StringLength(100, MinimumLength = 5)] string? txt) => txt;
 
         public Sample? GetSample(Sample? obj) => obj;
 
@@ -111,9 +112,27 @@ public partial class PipelineExecutionTests
     }
 
     [ExtendObjectType(OperationTypeNames.Mutation)]
-    public class MutationExtension
+    public class MutationExtensionByName
     {
-        public NestedParent SetNestedParentExt([Parent] Mutation parent, NestedParent obj) => parent.SetNestedParent(obj);
+        public NestedParent SetNestedParentExtByName([Parent] Mutation parent, NestedParent obj) => parent.SetNestedParent(obj);
+    }
+
+    [ExtendObjectType(OperationType.Mutation)]
+    public class MutationExtensionByOperationType
+    {
+        public NestedParent SetNestedParentExtByOpType([Parent] Mutation parent, NestedParent obj) => parent.SetNestedParent(obj);
+    }
+
+    [ExtendObjectType(typeof(Mutation))]
+    public class MutationExtensionByType
+    {
+        public NestedParent SetNestedParentExtByType([Parent] Mutation parent, NestedParent obj) => parent.SetNestedParent(obj);
+    }
+
+    [ExtendObjectType<Mutation>]
+    public class MutationExtensionGeneric
+    {
+        public NestedParent SetNestedParentExtGeneric([Parent] Mutation parent, NestedParent obj) => parent.SetNestedParent(obj);
     }
 
     [ExtendObjectType<Sample>]

--- a/DataAnnotatedModelValidations.Tests/Pipeline/PipelineExecutionTests.cs
+++ b/DataAnnotatedModelValidations.Tests/Pipeline/PipelineExecutionTests.cs
@@ -164,7 +164,7 @@ public partial class PipelineExecutionTests
     [InlineData(
         """
         mutation { 
-            setNestedParentExt(obj: { 
+            setNestedParentExtByName(obj: { 
                 child: { count: 0 }, 
                 children: [
                     { count: 1 }, 
@@ -177,7 +177,61 @@ public partial class PipelineExecutionTests
         }
         """,
         3,
-        "setNestedParentExt_nested_validations_ext"
+        "setNestedParentExt_nested_validations_ext_byName"
+    )]
+    [InlineData(
+        """
+        mutation { 
+            setNestedParentExtByOpType(obj: { 
+                child: { count: 0 }, 
+                children: [
+                    { count: 1 }, 
+                    { count: 0 }
+                ] 
+            }) { 
+                child { count } 
+                children { count } 
+            } 
+        }
+        """,
+        3,
+        "setNestedParentExt_nested_validations_ext_byOpType"
+    )]
+    [InlineData(
+        """
+        mutation { 
+            setNestedParentExtByType(obj: { 
+                child: { count: 0 }, 
+                children: [
+                    { count: 1 }, 
+                    { count: 0 }
+                ] 
+            }) { 
+                child { count } 
+                children { count } 
+            } 
+        }
+        """,
+        3,
+        "setNestedParentExt_nested_validations_ext_byType"
+    )]
+    [InlineData(
+        """
+        mutation { 
+            setNestedParentExtGeneric(obj: { 
+                child: { count: 0 }, 
+                children: [
+                    { count: 1 }, 
+                    { count: 0 }
+                ] 
+            }) { 
+                child { count } 
+                children { count } 
+            } 
+        }
+        """,
+        3,
+        "setNestedParentExt_nested_validations_ext_generic"
     )]
     public async Task Validation_Should_Return_Expected_Errors(string query, int? numberOfErrors, string description)
     {
@@ -189,7 +243,10 @@ public partial class PipelineExecutionTests
                 .AddQueryType<Query>()
                 .AddMutationType<Mutation>()
                 .AddTypeExtension<QueryExtension>()
-                .AddTypeExtension<MutationExtension>()
+                .AddTypeExtension<MutationExtensionByName>()
+                .AddTypeExtension<MutationExtensionByOperationType>()
+                .AddTypeExtension<MutationExtensionByType>()
+                .AddTypeExtension<MutationExtensionGeneric>()
                 .AddSorting()
                 .AddFiltering()
                 .ExecuteRequestAsync(query)

--- a/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_byName.snap
+++ b/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_byName.snap
@@ -1,0 +1,67 @@
+﻿{
+  "errors": [
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByName",
+        "obj",
+        "child"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByName",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    },
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByName",
+        "obj",
+        "count"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByName",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    },
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByName",
+        "obj",
+        "children",
+        "_1_",
+        "count"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByName",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    }
+  ],
+  "data": null
+}

--- a/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_byOpType.snap
+++ b/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_byOpType.snap
@@ -1,0 +1,67 @@
+﻿{
+  "errors": [
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByOpType",
+        "obj",
+        "child"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByOpType",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    },
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByOpType",
+        "obj",
+        "count"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByOpType",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    },
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByOpType",
+        "obj",
+        "children",
+        "_1_",
+        "count"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByOpType",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    }
+  ],
+  "data": null
+}

--- a/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_byType.snap
+++ b/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_byType.snap
@@ -1,0 +1,67 @@
+﻿{
+  "errors": [
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByType",
+        "obj",
+        "child"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByType",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    },
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByType",
+        "obj",
+        "count"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByType",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    },
+    {
+      "message": "The field Count must be between 1 and 10.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "setNestedParentExtByType",
+        "obj",
+        "children",
+        "_1_",
+        "count"
+      ],
+      "extensions": {
+        "code": "DAMV-400",
+        "field": "setNestedParentExtByType",
+        "type": "Mutation",
+        "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
+      }
+    }
+  ],
+  "data": null
+}

--- a/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_generic.snap
+++ b/DataAnnotatedModelValidations.Tests/Pipeline/__snapshots__/PipelineExecutionTests.Validation_Should_Return_Expected_Errors_setNestedParentExt_nested_validations_ext_generic.snap
@@ -9,13 +9,13 @@
         }
       ],
       "path": [
-        "setNestedParentExt",
+        "setNestedParentExtGeneric",
         "obj",
         "child"
       ],
       "extensions": {
         "code": "DAMV-400",
-        "field": "setNestedParentExt",
+        "field": "setNestedParentExtGeneric",
         "type": "Mutation",
         "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
       }
@@ -29,13 +29,13 @@
         }
       ],
       "path": [
-        "setNestedParentExt",
+        "setNestedParentExtGeneric",
         "obj",
         "count"
       ],
       "extensions": {
         "code": "DAMV-400",
-        "field": "setNestedParentExt",
+        "field": "setNestedParentExtGeneric",
         "type": "Mutation",
         "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
       }
@@ -49,7 +49,7 @@
         }
       ],
       "path": [
-        "setNestedParentExt",
+        "setNestedParentExtGeneric",
         "obj",
         "children",
         "_1_",
@@ -57,7 +57,7 @@
       ],
       "extensions": {
         "code": "DAMV-400",
-        "field": "setNestedParentExt",
+        "field": "setNestedParentExtGeneric",
         "type": "Mutation",
         "specifiedBy": "https://spec.graphql.org/June2018/#sec-Values-of-Correct-Type"
       }

--- a/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
+++ b/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
@@ -6,7 +6,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageId>$(MSBuildProjectName)</PackageId>
-        <Version>8.1.1</Version>
+        <Version>8.1.2</Version>
         <Authors>Adamos Fiakkas</Authors>
         <Description>Data Annotated Model Validation Middleware for HotChocolate</Description>
         <Copyright>Adamos Fiakkas</Copyright>

--- a/DataAnnotatedModelValidations/README.md
+++ b/DataAnnotatedModelValidations/README.md
@@ -16,6 +16,7 @@ In addition, individual method arguments can be validated using annotations from
 
 | HotChocolate Version | DataAnnotatedModelValidations Version | .NET Version |
 |----------------------|---------------------------------------|--------------|
+| 15.0.3 or higher     | 8.1.2                                 | .NET 8, 9    |
 | 15.0.3 or higher     | 8.1.1                                 | .NET 8, 9    |
 | 15.0.3 or higher     | 8.1.0                                 | .NET 8, 9    |
 | 15.0.3 or higher     | 8.0.1                                 | .NET 8, 9    |

--- a/DataAnnotatedModelValidations/TypeInterceptors/ValidatorTypeInterceptor.cs
+++ b/DataAnnotatedModelValidations/TypeInterceptors/ValidatorTypeInterceptor.cs
@@ -14,15 +14,18 @@ public sealed class ValidatorTypeInterceptor : TypeInterceptor
     private static IBindableList<ObjectFieldDefinition>? ObjectTypeDefinitionFields(DefinitionBase? definition) =>
         definition switch
         {
-            ObjectTypeDefinition
-            {
-                Name: OperationTypeNames.Query
-                or OperationTypeNames.Mutation
-                or OperationTypeNames.Subscription,
-                Fields.Count: > 0
-            } objectTypeDefinition => objectTypeDefinition.Fields,
+            ObjectTypeDefinition { Fields.Count: > 0 } objectTypeDefinition
+                when IsRootOperationType(objectTypeDefinition) => objectTypeDefinition.Fields,
             _ => default
         };
+
+    private static bool IsRootOperationType(ObjectTypeDefinition objectTypeDefinition) =>
+        IsRootOperationTypeName(objectTypeDefinition.ExtendsType?.Name ?? objectTypeDefinition.Name);
+
+    private static bool IsRootOperationTypeName(string? name) =>
+        name is OperationTypeNames.Query
+             or OperationTypeNames.Mutation
+             or OperationTypeNames.Subscription;
 
     private static ValidationAttribute[] GetValidationAttributes(ParameterInfo parameter) =>
         parameter.GetCustomAttributes(Consts.ValidationAttributeType, true) switch


### PR DESCRIPTION
## Overview
After upgrading to the latest version of this validation library, validation was not occurring when root types were being extended using some of the Hot Chocolate extension constructions:
- By Type (`ExtendObjectType(Type type)`)
- Generic (`ExtendObjectType<T>)()`)

Appears this was due to some changes in the type interceptor that focused on the `Name` of the object definition (which is not set the same way for all Hot Chocolate object extension constructions).

The update now checks to see if the name of the object your extending OR the object itself is a root type when determining whether or not to apply validation.

## Changes
- Update the `ValidatorTypeInterceptor` to properly handle extension via all of Hot Chocolate's construction methods
- Add new tests with matching snapshots

## Testing
- Ran all automated tests as well as used this in a local project.