### PR TITLE
Remove Humanizer dependency

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.0",
+      "version": "5.5.4",
       "commands": [
         "reportgenerator"
       ],

--- a/DataAnnotatedModelValidations.Tests/Extensions/StringExtensionsTests.cs
+++ b/DataAnnotatedModelValidations.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,23 @@
+﻿using DataAnnotatedModelValidations.Extensions;
+
+namespace DataAnnotatedModelValidations.Tests.Extensions;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("HelloWorld[0]", "helloWorld[0]")] // Should leave brackets and numbers alone
+
+    // Match the tests found in HotChocolate - DefaultNamingConventionsTests.cs
+    [InlineData("f", "f")]
+    [InlineData("IOFile", "ioFile")]
+    [InlineData("FooBar", "fooBar")]
+    [InlineData("FOO1Bar", "foo1Bar")]
+    [InlineData("FOO_Bar", "foo_Bar")]
+    [InlineData("FOO", "foo")]
+    [InlineData("FOo", "fOo")]
+    [InlineData("FOOBarBaz", "fooBarBaz")]
+    [InlineData("FoO", "foO")]
+    [InlineData("F", "f")]
+    public void GetCamelCaseName(string input, string expected) =>
+        Assert.Equal(expected, input.Camelize());
+}

--- a/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
+++ b/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="HotChocolate.Execution" Version="15.1.11" />
-    <PackageReference Include="Humanizer" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
+++ b/DataAnnotatedModelValidations/DataAnnotatedModelValidations.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageId>$(MSBuildProjectName)</PackageId>
-    <Version>9.0.0</Version>
+    <Version>10.0.0</Version>
     <Authors>Adamos Fiakkas</Authors>
     <Description>Data Annotated Model Validation Middleware for HotChocolate</Description>
     <Copyright>Adamos Fiakkas</Copyright>

--- a/DataAnnotatedModelValidations/Extensions/StringExtensions.cs
+++ b/DataAnnotatedModelValidations/Extensions/StringExtensions.cs
@@ -1,0 +1,43 @@
+using DataAnnotatedModelValidations.Utils;
+
+namespace DataAnnotatedModelValidations.Extensions;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Formats a field name to camelCase.
+    /// </summary>
+    /// <remarks>
+    /// Examples:
+    /// <list type="bullet">
+    ///   <item><c>FOOBar</c> → <c>fooBar</c></item>
+    ///   <item><c>FOO1Ar</c> → <c>foo1Ar</c></item>
+    ///   <item><c>FOO_Ar</c> → <c>foo_Ar</c></item>
+    ///   <item><c>ID</c> → <c>id</c></item>
+    /// </list>
+    /// </remarks>
+    internal static string Camelize(this string fieldName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fieldName);
+
+        // If the first character is already lowercase, return as is.
+        if (char.IsLower(fieldName[0]))
+        {
+            return fieldName;
+        }
+
+        return RegexUtils.LeadingUppercaseRegularExpression.Replace(fieldName, match =>
+        {
+            var upper = match.Value;
+            var nextIndex = match.Length;
+
+            // If only one uppercase char, or followed by non-letter, lowercase all
+            if (upper.Length == 1 || nextIndex >= fieldName.Length || !char.IsLower(fieldName[nextIndex]))
+                return upper.ToLowerInvariant();
+
+            // Multiple uppercase chars followed by lowercase: keep last uppercase
+            // (it starts the next camelCase word)
+            return upper[..^1].ToLowerInvariant() + upper[^1];
+        });
+    }
+}

--- a/DataAnnotatedModelValidations/Extensions/StringExtensions.cs
+++ b/DataAnnotatedModelValidations/Extensions/StringExtensions.cs
@@ -1,43 +1,52 @@
-using DataAnnotatedModelValidations.Utils;
-
 namespace DataAnnotatedModelValidations.Extensions;
 
 internal static class StringExtensions
 {
-    /// <summary>
-    /// Formats a field name to camelCase.
-    /// </summary>
-    /// <remarks>
-    /// Examples:
-    /// <list type="bullet">
-    ///   <item><c>FOOBar</c> → <c>fooBar</c></item>
-    ///   <item><c>FOO1Ar</c> → <c>foo1Ar</c></item>
-    ///   <item><c>FOO_Ar</c> → <c>foo_Ar</c></item>
-    ///   <item><c>ID</c> → <c>id</c></item>
-    /// </list>
-    /// </remarks>
-    internal static string Camelize(this string fieldName)
+    // Adaption of HC FormatFieldName(string fieldName)
+    // @see HotChocolate.Types.Descriptors.NameFormattingHelpers.FormatFieldName
+    internal static string Camelize(this string memberName)
     {
-        ArgumentException.ThrowIfNullOrEmpty(fieldName);
+        ArgumentException.ThrowIfNullOrEmpty(memberName);
 
-        // If the first character is already lowercase, return as is.
-        if (char.IsLower(fieldName[0]))
+        // quick exit
+        if (char.IsLower(memberName[0]))
         {
-            return fieldName;
+            return memberName;
         }
 
-        return RegexUtils.LeadingUppercaseRegularExpression.Replace(fieldName, match =>
-        {
-            var upper = match.Value;
-            var nextIndex = match.Length;
+        return string.Create(
+            length: memberName.Length, 
+            state: memberName, 
+            (output, fieldName) =>
+            {
+                int p = 0;
+                for (; p < fieldName.Length && char.IsLetter(fieldName[p]) && char.IsUpper(fieldName[p]); p++)
+                {
+                    output[p] = char.ToLowerInvariant(fieldName[p]);
+                }
 
-            // If only one uppercase char, or followed by non-letter, lowercase all
-            if (upper.Length == 1 || nextIndex >= fieldName.Length || !char.IsLower(fieldName[nextIndex]))
-                return upper.ToLowerInvariant();
+                // in case more than one character is upper case, we uppercase
+                // the current character. We only uppercase the character
+                // back if the last character is a letter
+                //
+                // before    after      result
+                // FOOBar    FOOBar   = fooBar
+                //    ^        ^
+                // FOO1Ar    FOO1Ar   = foo1Ar
+                //   ^         ^
+                // FOO_Ar    FOO_Ar   = foo_Ar
+                //   ^         ^
+                if (p < fieldName.Length && p > 1 && char.IsLetter(fieldName[p]))
+                {
+                    output[p - 1] = char.ToUpperInvariant(output[p - 1]);
+                }
 
-            // Multiple uppercase chars followed by lowercase: keep last uppercase
-            // (it starts the next camelCase word)
-            return upper[..^1].ToLowerInvariant() + upper[^1];
-        });
+                // Copy the rest unchanged
+                for (; p < fieldName.Length; p++)
+                {
+                    output[p] = fieldName[p];
+                }
+            }
+        );
     }
 }

--- a/DataAnnotatedModelValidations/README.md
+++ b/DataAnnotatedModelValidations/README.md
@@ -16,17 +16,18 @@ In addition, individual method arguments can be validated using annotations from
 
 | HotChocolate Version | DataAnnotatedModelValidations Version | .NET Version  |
 | -------------------- | ------------------------------------- | ------------- |
-| 15.1.11 or higher    | 9.0.0                                 | .NET 8, 9, 10 |
-| 15.0.3 or higher     | 8.1.2                                 | .NET 8, 9     |
-| 15.0.3 or higher     | 8.1.1                                 | .NET 8, 9     |
-| 15.0.3 or higher     | 8.1.0                                 | .NET 8, 9     |
-| 15.0.3 or higher     | 8.0.1                                 | .NET 8, 9     |
-| 15.0.3 or higher     | 8.0.0                                 | .NET 8, 9     |
-| 15.0.3 or higher     | 7.0.0                                 | .NET 8, 9     |
-| 14.3.0 or higher     | 6.3.0                                 | .NET 8, 9     |
-| 14.2.0 or higher     | 6.2.0                                 | .NET 8, 9     |
-| 14.1.0 or higher     | 6.1.0                                 | .NET 8, 9     |
-| 14.0.0 or higher     | 6.0.0                                 | .NET 8        |
+| 15.1.11 or higher    | 10.0.0                                | .NET 8, 9, 10 |
+| 15.1.11 or higher    |  9.0.0                                | .NET 8, 9, 10 |
+| 15.0.3 or higher     |  8.1.2                                | .NET 8, 9     |
+| 15.0.3 or higher     |  8.1.1                                | .NET 8, 9     |
+| 15.0.3 or higher     |  8.1.0                                | .NET 8, 9     |
+| 15.0.3 or higher     |  8.0.1                                | .NET 8, 9     |
+| 15.0.3 or higher     |  8.0.0                                | .NET 8, 9     |
+| 15.0.3 or higher     |  7.0.0                                | .NET 8, 9     |
+| 14.3.0 or higher     |  6.3.0                                | .NET 8, 9     |
+| 14.2.0 or higher     |  6.2.0                                | .NET 8, 9     |
+| 14.1.0 or higher     |  6.1.0                                | .NET 8, 9     |
+| 14.0.0 or higher     |  6.0.0                                | .NET 8        |
 
 ### Past Releases
 

--- a/DataAnnotatedModelValidations/Usings.cs
+++ b/DataAnnotatedModelValidations/Usings.cs
@@ -5,7 +5,6 @@ global using HotChocolate.Types.Descriptors.Definitions;
 global using HotChocolate.Types.Descriptors;
 global using HotChocolate.Types;
 global using HotChocolate;
-global using Humanizer;
 global using Microsoft.Extensions.DependencyInjection;
 global using System.Collections.Generic;
 global using System.ComponentModel.DataAnnotations;

--- a/DataAnnotatedModelValidations/Usings.cs
+++ b/DataAnnotatedModelValidations/Usings.cs
@@ -2,7 +2,6 @@ global using HotChocolate.Configuration;
 global using HotChocolate.Execution.Configuration;
 global using HotChocolate.Resolvers;
 global using HotChocolate.Types.Descriptors.Definitions;
-global using HotChocolate.Types.Descriptors;
 global using HotChocolate.Types;
 global using HotChocolate;
 global using Microsoft.Extensions.DependencyInjection;

--- a/DataAnnotatedModelValidations/Utils/RegexUtils.cs
+++ b/DataAnnotatedModelValidations/Utils/RegexUtils.cs
@@ -7,4 +7,13 @@ internal static partial class RegexUtils
     [ExcludeFromCodeCoverage]
     [GeneratedRegex(@"[\[\]]+", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
     private static partial Regex BracketsRegex();
+
+    internal static Regex LeadingUppercaseRegularExpression { get; } = LeadingUppercaseRegex();
+
+    /// <summary>
+    /// Matches leading uppercase letters for camelCase conversion.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [GeneratedRegex(@"^[A-Z]+", RegexOptions.Compiled)]
+    private static partial Regex LeadingUppercaseRegex();
 }

--- a/DataAnnotatedModelValidations/Utils/RegexUtils.cs
+++ b/DataAnnotatedModelValidations/Utils/RegexUtils.cs
@@ -7,13 +7,4 @@ internal static partial class RegexUtils
     [ExcludeFromCodeCoverage]
     [GeneratedRegex(@"[\[\]]+", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
     private static partial Regex BracketsRegex();
-
-    internal static Regex LeadingUppercaseRegularExpression { get; } = LeadingUppercaseRegex();
-
-    /// <summary>
-    /// Matches leading uppercase letters for camelCase conversion.
-    /// </summary>
-    [ExcludeFromCodeCoverage]
-    [GeneratedRegex(@"^[A-Z]+", RegexOptions.Compiled)]
-    private static partial Regex LeadingUppercaseRegex();
 }


### PR DESCRIPTION
This drops the dependency on Humanizer for just a single function call. The 'Camelize' extension is now moved internal and adjusted to match HotChocolate's own internal `FormatFieldName` function. Added unit tests to match HC's naming tests as well.